### PR TITLE
Add simple timelapse gallery prototype

### DIFF
--- a/timelapse-gallery/README.md
+++ b/timelapse-gallery/README.md
@@ -1,0 +1,5 @@
+# Electra Timelapse Gallery
+
+This is a simple prototype of a timelapse gallery inspired by OBS layout.
+
+Open `index.html` in your browser to try it out. You can add camera image URLs and enable slideshow mode from the sidebar.

--- a/timelapse-gallery/app.js
+++ b/timelapse-gallery/app.js
@@ -1,0 +1,104 @@
+const { useState, useEffect, useRef } = React;
+
+function Sidebar({ cameras, selected, onSelect, onAdd, slideshow, setSlideshow }) {
+  const [newName, setNewName] = useState('');
+  const [newUrl, setNewUrl] = useState('');
+  const [intervalSec, setIntervalSec] = useState(5);
+
+  const addCamera = () => {
+    if (!newName || !newUrl) return;
+    onAdd({ name: newName, url: newUrl, status: 'Live' });
+    setNewName('');
+    setNewUrl('');
+  };
+
+  return (
+    <div className="w-64 bg-black text-white p-4 flex flex-col space-y-4 h-full overflow-y-auto">
+      <h1 className="text-xl font-bold">Cameras</h1>
+      <div className="flex-1 space-y-2">
+        {cameras.map((cam, idx) => (
+          <div
+            key={idx}
+            className={`p-2 rounded cursor-pointer ${selected === idx ? 'bg-gray-700' : 'bg-gray-900'}`}
+            onClick={() => onSelect(idx)}
+          >
+            {cam.name}
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2">
+        <h2 className="font-semibold">Add Camera</h2>
+        <input className="w-full p-1 text-black" placeholder="Name" value={newName} onChange={e => setNewName(e.target.value)} />
+        <input className="w-full p-1 text-black" placeholder="URL" value={newUrl} onChange={e => setNewUrl(e.target.value)} />
+        <button className="w-full bg-blue-600 p-1 rounded" onClick={addCamera}>Add</button>
+      </div>
+      <div className="space-y-2 border-t border-gray-600 pt-2">
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={slideshow} onChange={e => setSlideshow(e.target.checked)} />
+          <span>Slideshow Mode</span>
+        </label>
+        <input
+          type="number"
+          className="w-full p-1 text-black"
+          value={intervalSec}
+          onChange={e => setIntervalSec(parseInt(e.target.value) || 1)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CameraGrid({ cameras, selected, onDelete }) {
+  return (
+    <div className="flex-1 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4 overflow-auto">
+      {cameras.map((cam, idx) => (
+        <div key={idx} className="rounded shadow bg-white relative">
+          <div className="p-2 font-semibold bg-gray-800 text-white rounded-t">{cam.name}</div>
+          <div className="p-2">
+            <img src={cam.url} alt={cam.name} className="w-full h-48 object-cover" />
+          </div>
+          <div className="absolute top-1 right-1 space-x-1">
+            <button className="bg-red-600 text-white px-2 py-1 rounded" onClick={() => onDelete(idx)}>Delete</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function App() {
+  const [cameras, setCameras] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [slideshow, setSlideshow] = useState(false);
+  const slideshowRef = useRef(null);
+
+  useEffect(() => {
+    if (slideshow) {
+      slideshowRef.current = setInterval(() => {
+        setSelected(prev => (prev === null ? 0 : (prev + 1) % cameras.length));
+      }, 5000);
+    } else {
+      clearInterval(slideshowRef.current);
+    }
+    return () => clearInterval(slideshowRef.current);
+  }, [slideshow, cameras]);
+
+  const addCamera = cam => setCameras([...cameras, cam]);
+  const deleteCamera = idx => setCameras(cameras.filter((_, i) => i !== idx));
+
+  return (
+    <div className="flex h-full">
+      <Sidebar
+        cameras={cameras}
+        selected={selected}
+        onSelect={setSelected}
+        onAdd={addCamera}
+        slideshow={slideshow}
+        setSlideshow={setSlideshow}
+      />
+      <CameraGrid cameras={selected !== null ? [cameras[selected]] : cameras} selected={selected} onDelete={deleteCamera} />
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/timelapse-gallery/index.html
+++ b/timelapse-gallery/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Electra Timelapse Gallery</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body class="h-screen flex">
+  <div id="root" class="flex-1"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple static prototype for an "Electra Timelapse Gallery"
- sidebar lists cameras and allows adding new ones and enabling slideshow mode
- grid shows camera feeds and allows deleting cameras

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405008f5408320902e6ae21fe39edb